### PR TITLE
Add python3.14 compatibility

### DIFF
--- a/draytek_arsenal/requirements.txt
+++ b/draytek_arsenal/requirements.txt
@@ -4,9 +4,10 @@ charset-normalizer==3.3.2
 docker==7.1.0
 idna==3.7
 kaitaistruct==0.10
-lief==0.16.1
+lief==0.17.6
 lz4==4.3.3
 PyYAML==6.0.1
 requests==2.32.0
 urllib3==2.2.2
 hexdump==3.3
+pycryptodome==3.23.0


### PR DESCRIPTION
When running this code using recent versions of python an additional dependency providing the Crypto module is needed. This pull requests adds pycryptodome for this purpose.
lief 0.16.1 is also not available for python3.14, so it was updated to 0.17.6