### PR TITLE
feature: automatic installation of dependencies

### DIFF
--- a/draytek_arsenal/pyproject.toml
+++ b/draytek_arsenal/pyproject.toml
@@ -8,3 +8,11 @@ authors = [
 description = "A package to help security assignments on Draytek firmwaresDraytek Arsenal is a set of tools designed to enhance the security of Draytek edge devices. Written as a Python package and utilizing Docker, this toolkit empowers defenders and researchers to analyze, modify, and strengthen Draytek firmware. With features like firmware format parsing, module management, and integrity-checking module compilation, Draytek Arsenal offers a comprehensive solution for firmware analysis and customization. Accessible to the cybersecurity community under a MIT license, this toolset encourages collaboration and transparency in the pursuit of a more secure internet."
 readme = "README.md"
 requires-python = ">=3.10"
+dynamic = ["dependencies"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Adds the given requirements.txt to the pyproject.toml using setuptools.

This allows users to install the command line tool with all its dependencies using one simple command:
`pip install git+https://github.com/infobyte/draytek-arsenal#subdirectory=draytek_arsenal`